### PR TITLE
Use cast instead of untyped for _getTarget().

### DIFF
--- a/tweenx909/advanced/StandardTweenX.hx
+++ b/tweenx909/advanced/StandardTweenX.hx
@@ -39,7 +39,7 @@ class StandardTweenX<T> extends TweenX {
 		#end
 	}
 	
-	private function _getTarget():T { return untyped this; }
+	private function _getTarget():T { return cast this; }
 	private function _setTo( key:String, value:Dynamic ):Void {
 		checkInited();
 		switch( _type ) {


### PR DESCRIPTION
Fixed compilation issue for Java target:

``` haxe
class Test {
    static function main() {
        tweenx909.TweenX.to({}, {});
    }
}
```

The above produced the following compilation error:

```
haxelib run hxjava hxjava_build.txt --haxe-version 3101
javac "-sourcepath" "src" "-d" "obj" "-g" "@cmd"
src/tweenx909/advanced/StandardTweenX.java:115: error: incompatible types
        return this;
               ^
  required: T
  found:    StandardTweenX<T>
  where T is a type-variable:
    T extends Object declared in class StandardTweenX
1 error
Compilation error
Native compilation failed
Error: Build failed
[Finished in 2.1s with exit code 1]
[cmd: ['haxe', 'build.hxml']]
[dir: /Users/andy/Documents/workspace/TestHaxe]
[path: /usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin]
```
