### PR TITLE
Fix deprecation warning in GraphColor

### DIFF
--- a/tools/CustumEasing/src/component/basic/GraphColor.hx
+++ b/tools/CustumEasing/src/component/basic/GraphColor.hx
@@ -1,6 +1,6 @@
 package component.basic;
 
-@:enum
+#if (haxe_ver < 4.3) @:enum #else enum #end
 abstract GraphColor(Int) to Int
 {
 	var Theme = 0x0E5ABB;


### PR DESCRIPTION
Per docs, haxe 4 introduces `enum abstract` as first class syntax, and the old `@:enum` metadata is deprecated now.

This change adds a quick haxe_ver guard to avoid breaking haxe 3, while solving the deprecation warnings for modern haxe versions.